### PR TITLE
Testing Robot.run()

### DIFF
--- a/com.rutgers.asearch/src/Main.java
+++ b/com.rutgers.asearch/src/Main.java
@@ -5,35 +5,6 @@ import java.util.*;
 
 public class Main {
 
-    public static GridWorldInfo runRobot(Robot rob, Grid grid, SearchAlgo algo) {
-        // statistics to be collected and returned
-        double totalTrajectoryLength = 0;
-        int totalCellsProcessed = 0;
-        ArrayList<Tuple<Integer, Integer>> totalPath = new ArrayList<>();
-
-        // while robot has not reached the destination
-        while(rob.getLocation().f1.intValue() != rob.getGoal().f1.intValue() || rob.getLocation().f2.intValue() != rob.getGoal().f2.intValue()) {
-            // find path
-            GridWorldInfo result = algo.search(rob.getLocation(), rob.getGoal(), grid, rob.getKnownObstacles()::contains);
-            totalCellsProcessed += result.getNumberOfCellsProcessed();
-
-            // if no path found, exit with failure
-            if(result.getPath() == null) {
-                totalTrajectoryLength = Double.NaN;
-                totalPath = null;
-                break;
-            }
-
-            // else, attempt to move along that path, and update the overall path taken
-            int stepsTaken = rob.run(result.getPath(), grid);
-            totalTrajectoryLength += stepsTaken;
-            totalPath.addAll(result.getPath().subList(0, stepsTaken));
-        }
-
-        // return output
-        return new GridWorldInfo(totalTrajectoryLength, totalCellsProcessed, totalPath);
-    }
-
     public static void runProbabilitySimulation(int xDimension, int yDimension, int numberOfIterations, boolean canSeeSideways) {
         ArrayList<GridWorldInfo> solutionDensity = new ArrayList<>();
         for (int i = 0; i <= 100; i++){

--- a/com.rutgers.asearch/src/Robot.java
+++ b/com.rutgers.asearch/src/Robot.java
@@ -7,6 +7,7 @@ public class Robot {
     private Tuple<Integer, Integer> goal;
     private boolean canSeeSideways;
     private HashSet<GridCell> blocked;
+    private HashSet<GridCell> free;
     private Grid grid;
     private SearchAlgo searchAlgo;
 
@@ -15,6 +16,7 @@ public class Robot {
         this.goal = goal;
         this.canSeeSideways = canSeeSideways;
         this.blocked = new HashSet<>();
+        this.free = new HashSet<>();
         this.grid = grid;
         this.searchAlgo = searchAlgo;
     }
@@ -35,8 +37,16 @@ public class Robot {
         return blocked;
     }
 
+    public HashSet<GridCell> getKnownFreeSpaces() {
+        return free;
+    }
+
     public void addObstacle(GridCell obstacle) {
         blocked.add(obstacle);
+    }
+
+    public void addFreeSpace(GridCell freeSpace) {
+        free.add(freeSpace);
     }
 
     public Grid getGrid() {
@@ -62,14 +72,20 @@ public class Robot {
 
                 for(Tuple<Integer, Integer> direction : directions) {
                     GridCell cell = grid.getCell(direction);
-                    if(cell != null && cell.isBlocked()) addObstacle(cell);
+                    if(cell != null) {
+                        if(cell.isBlocked()) addObstacle(cell);
+                        else addFreeSpace(cell);
+                    }
                 }
             }
-            if(grid.getCell(position).isBlocked()) { // if bump into an obstacle, stop
-                addObstacle(grid.getCell(position));
+
+            GridCell nextCell = grid.getCell(position);
+            if(nextCell.isBlocked()) { // if bump into an obstacle, stop
+                addObstacle(nextCell);
                 break;
             } else {
                 numStepsTaken++;
+                addFreeSpace(nextCell);
                 move(position);
             }
         }

--- a/com.rutgers.asearch/src/Robot.java
+++ b/com.rutgers.asearch/src/Robot.java
@@ -17,6 +17,7 @@ public class Robot {
         this.canSeeSideways = canSeeSideways;
         this.blocked = new HashSet<>();
         this.free = new HashSet<>();
+        this.free.add(grid.getCell(start)); // start cell is always known/assumed to be free
         this.grid = grid;
         this.searchAlgo = searchAlgo;
     }

--- a/com.rutgers.asearch/src/Robot.java
+++ b/com.rutgers.asearch/src/Robot.java
@@ -37,9 +37,11 @@ public class Robot {
 
     // attempt to follow a path, updating known obstacles along the way
     // stops prematurely if it bumps into an obstacle
-    public void run(List<Tuple<Integer, Integer>> path, Grid grid) {
+    // returns the number of steps successfully traveled
+    public int run(List<Tuple<Integer, Integer>> path, Grid grid) {
+        int numStepsTaken = 0;
         for(Tuple<Integer, Integer> position : path) {
-            if(this.canSeeSideways) { // update obstacles baseed on fov
+            if(this.canSeeSideways) { // update obstacles based on fov
                 ArrayList<Tuple<Integer, Integer>> directions = new ArrayList<>(4);
                 directions.add(new Tuple<>(this.current.f1 + 1, this.current.f2)); // right
                 directions.add(new Tuple<>(this.current.f1 - 1, this.current.f2)); // left
@@ -56,8 +58,11 @@ public class Robot {
                 this.blocked.add(grid.getCell(position));
                 break;
             } else {
+                numStepsTaken++;
                 this.move(position);
             }
         }
+
+        return numStepsTaken;
     }
 }

--- a/com.rutgers.asearch/src/Robot.java
+++ b/com.rutgers.asearch/src/Robot.java
@@ -85,8 +85,8 @@ public class Robot {
 
             // if no path found, exit with failure
             if(result == null || result.getPath() == null) {
-                gridWorldInfoGlobal.getPath().clear();
-                gridWorldInfoGlobal.setTrajectoryLength(0);
+                gridWorldInfoGlobal.setPath(null);
+                gridWorldInfoGlobal.setTrajectoryLength(Double.NaN);
                 return gridWorldInfoGlobal;
             }
 

--- a/com.rutgers.asearch/src/Test.java
+++ b/com.rutgers.asearch/src/Test.java
@@ -3,7 +3,7 @@ import java.util.*;
 // just tests the search algos to make sure they work
 // usage: java Test xSize ySize blockedProbability%
 public class Test {
-    public static void printResults(GridWorldInfo result, Grid world, Robot rob) {
+    public static void printResults(GridWorldInfo result, Grid world, Robot robot) {
         System.out.println("num cells expanded: " + result.getNumberOfCellsProcessed());
         System.out.println("trajectory length: " + result.getTrajectoryLength());
 
@@ -21,7 +21,7 @@ public class Test {
                 GridCell cell = world.getCell(new Tuple<>(i, j));
                 String symbol = "o"; // default symbol
                 if(trajectory.contains(cell)) symbol = "\u001B[36m-\u001B[0m";
-                else if(rob.getKnownObstacles().contains(cell)) symbol = "\u001B[33mx\u001B[0m";
+                else if(robot.getKnownObstacles().contains(cell)) symbol = "\u001B[33mx\u001B[0m";
                 else if(cell.isBlocked()) symbol = "\u001B[31mx\u001B[0m";
                 System.out.print(symbol);
             }
@@ -37,17 +37,17 @@ public class Test {
 
         // test repeated A* search
         System.out.println("Testing Repeated A* ...");
-        aStarSearchObject aso = new aStarSearchObject(Heuristics::euclideanDistance);
+        SearchAlgo aso = new AStarSearch(Heuristics::euclideanDistance);
         Tuple<Integer, Integer> start = new Tuple<>(0, 0);
         Tuple<Integer, Integer> end = new Tuple<>(x-1, y-1);
-        Robot rob = new Robot(start, end, true);
-        GridWorldInfo result = Main.runRobot(rob, world, aso::aStarSearch);
-        printResults(result, world, rob);
+        Robot robot = new Robot(start, end, true, world, aso);
+        GridWorldInfo result = robot.run();
+        printResults(result, world, robot);
         System.out.println();
 
         // test regular A* search
         System.out.println("Testing A* ...");
-        result = aso.aStarSearch(start, end, world, cell -> cell.isBlocked());
-        printResults(result, world, new Robot(start, end, true));
+        result = aso.search(start, end, world, cell -> cell.isBlocked());
+        printResults(result, world, new Robot(start, end, true, world, aso));
     }
 }

--- a/com.rutgers.asearch/src/Test.java
+++ b/com.rutgers.asearch/src/Test.java
@@ -1,9 +1,10 @@
 import java.util.*;
+import java.util.function.Predicate;
 
 // just tests the search algos to make sure they work
 // usage: java Test xSize ySize blockedProbability%
 public class Test {
-    public static void printResults(GridWorldInfo result, Grid world, Robot robot) {
+    public static void printResults(GridWorldInfo result, Grid world, Robot robot, Predicate<GridCell> isBlocked) {
         System.out.println("num cells expanded: " + result.getNumberOfCellsProcessed());
         System.out.println("trajectory length: " + result.getTrajectoryLength());
 
@@ -22,7 +23,7 @@ public class Test {
                 String symbol = "o"; // default symbol
                 if(trajectory.contains(cell)) symbol = "\u001B[36m-\u001B[0m";
                 else if(robot.getKnownObstacles().contains(cell)) symbol = "\u001B[33mx\u001B[0m";
-                else if(cell.isBlocked()) symbol = "\u001B[31mx\u001B[0m";
+                else if(isBlocked.test(cell)) symbol = "\u001B[31mx\u001B[0m";
                 System.out.print(symbol);
             }
             System.out.print('\n');
@@ -36,18 +37,22 @@ public class Test {
         Grid world = new Grid(x, y, prob);
 
         // test repeated A* search
-        System.out.println("Testing Repeated A* ...");
-        SearchAlgo aso = new AStarSearch(Heuristics::euclideanDistance);
+        System.out.println("Testing Repeated A*...");
+        SearchAlgo aso = new AStarSearch(Heuristics::manhattanDistance);
         Tuple<Integer, Integer> start = new Tuple<>(0, 0);
         Tuple<Integer, Integer> end = new Tuple<>(x-1, y-1);
         Robot robot = new Robot(start, end, true, world, aso);
         GridWorldInfo result = robot.run();
-        printResults(result, world, robot);
+        printResults(result, world, robot, cell -> cell.isBlocked());
         System.out.println();
 
         // test regular A* search
-        System.out.println("Testing A* ...");
-        result = aso.search(start, end, world, cell -> cell.isBlocked());
-        printResults(result, world, new Robot(start, end, true, world, aso));
+        System.out.println("Running A* on discovered gridworld...");
+        Predicate<GridCell> discoveredAndFree = robot.getKnownFreeSpaces()::contains;
+        Predicate<GridCell> undiscoveredOrBlocked = discoveredAndFree.negate();
+        result = aso.search(start, end, world, undiscoveredOrBlocked);
+        printResults(result, world, robot, undiscoveredOrBlocked);
+
+
     }
 }


### PR DESCRIPTION
I tested the `Robot.run()` functionality and it seems to work as expected. There was an issue where the trajectory length and overall path were not being recorded correctly, because the trajectory length was always being incremented by the length of the entire path returned from the A* search, even if the robot did not move all the way through said path (ie b/c it hit an obstacle). To fix this I made `Robot.runPath()` return the length of the path the robot was able to successfully travel through before hitting an obstacle or reaching the goal, and then updated `gridWorldInfoGlobal` based on that.

Everything else seems to work, so I think we are ready to start collecting data for the non-extra credit stuff.
In addition to the data already processed by `Main.printResultsToCsv`, we also need the following data:
- "Length of Shortest Path in Full Gridworld"
- " Length of Shortest Path in Final Discovered Gridworld" -> (I am still not sure what exactly this means)
- Runtime (for extra credit)